### PR TITLE
Kill child process with SIGKILL on POSIX

### DIFF
--- a/System/Process/Kill.hs
+++ b/System/Process/Kill.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE CPP #-}
+module System.Process.Kill (killProcess) where
+import System.Process
+
+#if !defined(WINDOWS)
+import System.Process.Internals
+import qualified System.Posix.Signals as Sig
+#endif
+
+killProcess :: ProcessHandle -> IO ()
+killProcess ph =
+#if defined(WINDOWS)
+  -- terminateProcess should kill the process and its children.
+  terminateProcess ph
+#else
+  withProcessHandle ph $ \ph_ -> case ph_ of
+    OpenHandle pid -> sendKillSignal pid
+    ClosedHandle {} -> return ()
+#if MIN_VERSION_process(1, 5, 0)
+    OpenExtHandle pid _ _ -> sendKillSignal pid
+#endif
+  where
+    sendKillSignal = Sig.signalProcess Sig.killProcess
+#endif

--- a/System/Process/Kill.hs
+++ b/System/Process/Kill.hs
@@ -1,14 +1,16 @@
 {-# LANGUAGE CPP #-}
-module System.Process.Kill (killProcess) where
+module System.Process.Kill (killProcessTree) where
 import System.Process
 
 #if !defined(WINDOWS)
 import System.Process.Internals
 import qualified System.Posix.Signals as Sig
+import qualified System.Posix.Process as Proc
 #endif
 
-killProcess :: ProcessHandle -> IO ()
-killProcess ph =
+-- | Kill all processes in the same process group as the specified process.
+killProcessTree :: ProcessHandle -> IO ()
+killProcessTree ph =
 #if defined(WINDOWS)
   -- terminateProcess should kill the process and its children.
   terminateProcess ph
@@ -20,5 +22,7 @@ killProcess ph =
     OpenExtHandle pid _ _ -> sendKillSignal pid
 #endif
   where
-    sendKillSignal = Sig.signalProcess Sig.killProcess
+    sendKillSignal pid = do
+      pgid <- Proc.getProcessGroupIDOf pid
+      Sig.signalProcessGroup Sig.killProcess pgid
 #endif

--- a/sensu-run.cabal
+++ b/sensu-run.cabal
@@ -37,6 +37,12 @@ executable sensu-run
     , time >= 1.5.0.1 && < 1.9
     , vector >= 0.11 && < 0.13
     , wreq >= 0.5.0 && < 0.6
-  other-modules: Paths_sensu_run
+  other-modules:
+    Paths_sensu_run
+    System.Process.Kill
+  if os(windows)
+    cpp-options: -DWINDOWS
+  else
+    build-depends: unix
   ghc-options: -Wall -threaded
   default-language: Haskell2010

--- a/sensu-run.cabal
+++ b/sensu-run.cabal
@@ -31,7 +31,7 @@ executable sensu-run
     , lens >= 4.15 && < 4.16
     , network >= 2.2.3 && < 2.7
     , optparse-applicative >= 0.12 && < 0.15
-    , process >= 1.5 && < 1.7
+    , process >= 1.4 && < 1.7
     , temporary >= 1.1 && < 1.3
     , text >= 1.2.2 && < 1.3
     , time >= 1.5.0.1 && < 1.9

--- a/sensu-run.hs
+++ b/sensu-run.hs
@@ -43,7 +43,7 @@ import qualified Network.Socket.ByteString.Lazy as Socket
 import qualified Network.Wreq as W
 import qualified Options.Applicative as O
 
-import System.Process.Kill (killProcess)
+import System.Process.Kill (killProcessTree)
 import qualified Paths_sensu_run as Paths
 
 main :: IO ()
@@ -60,7 +60,7 @@ main = do
         (startProcess cmdspec hdl)
         (\ph -> do
           terminateProcess ph
-          killProcess ph
+          killProcessTree ph
           waitForProcess ph)
         (withTimeout timeout . waitForProcess)
       exited <- getCurrentTime
@@ -138,7 +138,7 @@ startProcess cmdspec hdl = do
     , std_out = UseHandle hdl
     , std_err = UseHandle hdl
     , close_fds = False
-    , create_group = False
+    , create_group = True -- necessary to not kill sensu-run itself
     , delegate_ctlc = False
     , detach_console = False
     , create_new_console = False

--- a/sensu-run.hs
+++ b/sensu-run.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiWayIf #-}
@@ -140,7 +141,9 @@ startProcess cmdspec hdl = do
     , new_session = False
     , child_group = Nothing
     , child_user = Nothing
+#if MIN_VERSION_process(1, 5, 0)
     , use_process_jobs = True
+#endif
     }
   return ph
 

--- a/sensu-run.hs
+++ b/sensu-run.hs
@@ -43,6 +43,7 @@ import qualified Network.Socket.ByteString.Lazy as Socket
 import qualified Network.Wreq as W
 import qualified Options.Applicative as O
 
+import System.Process.Kill (killProcess)
 import qualified Paths_sensu_run as Paths
 
 main :: IO ()
@@ -57,7 +58,10 @@ main = do
       executed <- getCurrentTime
       rawStatus <- bracket
         (startProcess cmdspec hdl)
-        terminateProcess
+        (\ph -> do
+          terminateProcess ph
+          killProcess ph
+          waitForProcess ph)
         (withTimeout timeout . waitForProcess)
       exited <- getCurrentTime
       rawOutput <- BL.readFile path


### PR DESCRIPTION
This closes #5.

`terminalteProcess` on POSIX systems doesn't guarantee that the process being terminated is actually killed. This PR fixes the issue by sending `kill -9` to the process.